### PR TITLE
Minor fixes

### DIFF
--- a/WindowsClientDAL/network/dtls/AsyncCertificateRequest.cs
+++ b/WindowsClientDAL/network/dtls/AsyncCertificateRequest.cs
@@ -138,9 +138,6 @@ namespace com.mobius.software.windows.iotbroker.network.dtls
                 if (null == result)
 				    throw new TlsFatalAlert(AlertDescription.decode_error);
 		        
-			    if (null != asn1.ReadObject())
-		            throw new TlsFatalAlert(AlertDescription.decode_error);
-
                 certificateAuthorities.Add(X509Name.GetInstance(result));
 			    remainingBytes-=2+derEncoding.Length;
 		    }

--- a/WindowsClientDAL/network/dtls/AsyncDtlsClientProtocol.cs
+++ b/WindowsClientDAL/network/dtls/AsyncDtlsClientProtocol.cs
@@ -272,6 +272,7 @@ namespace com.mobius.software.windows.iotbroker.network.dtls
             MemoryStream buf = new MemoryStream();
             clientState.KeyExchange.GenerateClientKeyExchange(buf);
             byte[] clientKeyExchange = buf.GetBuffer();
+            Array.Resize(ref clientKeyExchange, clientKeyExchange[0] + 1);
             IByteBuffer keyExchangeOutput = Unpooled.Buffer(DtlsHelper.HANDSHAKE_MESSAGE_HEADER_LENGTH + clientKeyExchange.Length);
             short currSequence = sequence++;
             DtlsHelper.WriteHandshakeHeader(currSequence,MessageType.CLIENT_KEY_EXCHANGE,keyExchangeOutput,clientKeyExchange.Length);


### PR DESCRIPTION
Truncate client's Key Exchange DTLS record to the actual size of the contained DHCE key for interoperability with mbedTLS peer (was hardcoded to 0x100)